### PR TITLE
A bunch of new general purpose scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Lists all authors from a share replica.
 
 Lists all document paths from a share replica.
 
+### `list_servers.ts`
+
+List all servers saved to shared settings.
+
+### `list_shares.ts`
+
+List all shares saved to shared settings.
+
 ### `new_author.ts`
 
 Generates a new author keypair from a shortname and adds it to shared settings

--- a/README.md
+++ b/README.md
@@ -92,9 +92,14 @@ your friend.
 
 Sync the contents of a filesystem directory with a share replica.
 
+### `sync_all.ts`
+
+Sync all known shares with all known servers (only shares held in common by both
+sides will be synced).
+
 ### `sync_with_server.ts`
 
-Sync a share replica with an Earthstar server.
+Sync one share replica with one Earthstar server.
 
 ### `write_replica`
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ The first argument is the URL to be saved.
 Archives a share replica's data to a zip file. You can then put that archive on
 a USB key and give it to a friend for syncing, or back it up.
 
+### `current_author.ts`
+
+Display the current author keypair saved to shared settings.
+
+### `forget_author.ts`
+
+Forget the current author keypair saved to shared settings.
+
 ### `list_authors.ts`
 
 Lists all authors from a share replica.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ other scripts to use.
 
 Removes a server from the list of servers known by `SharedSettings`.
 
+### `remove_share.ts`
+
+Removes a share from the list of known shares.
+
 ### `save_attachment.ts`
 
 Write an attachment to your filesystem.

--- a/scripts/current_author.ts
+++ b/scripts/current_author.ts
@@ -1,0 +1,13 @@
+import { Earthstar } from "../deps.ts";
+
+const settings = new Earthstar.SharedSettings();
+
+if (!settings.author) {
+  console.log("No author keypair currently saved to settings.");
+  Deno.exit(0);
+}
+
+console.group("Current author keypair:");
+console.log(settings.author.address);
+
+Deno.exit(0);

--- a/scripts/forget_author.ts
+++ b/scripts/forget_author.ts
@@ -1,0 +1,21 @@
+import { Earthstar } from "../deps.ts";
+
+const settings = new Earthstar.SharedSettings();
+
+if (!settings.author) {
+  console.log("No author keypair currently saved to settings.");
+  Deno.exit(0);
+}
+
+console.group("Current author keypair:");
+console.log(settings.author.address);
+
+const isSure = confirm("Are you sure you want to forget this keypair?");
+
+if (isSure) {
+  settings.author = null;
+
+  console.log("✅ Forgot author keypair");
+}
+
+Deno.exit(0);

--- a/scripts/list_servers.ts
+++ b/scripts/list_servers.ts
@@ -1,0 +1,11 @@
+import { Earthstar } from "../deps.ts";
+
+const settings = new Earthstar.SharedSettings();
+
+if (settings.servers.length === 0) {
+  console.log("No servers saved to shared settings.");
+}
+
+for (const share of settings.servers) {
+  console.log(share);
+}

--- a/scripts/list_shares.ts
+++ b/scripts/list_shares.ts
@@ -1,0 +1,11 @@
+import { Earthstar } from "../deps.ts";
+
+const settings = new Earthstar.SharedSettings();
+
+if (settings.shares.length === 0) {
+  console.log("No shares saved to shared settings.");
+}
+
+for (const share of settings.shares) {
+  console.log(share);
+}

--- a/scripts/remove_share.ts
+++ b/scripts/remove_share.ts
@@ -1,0 +1,37 @@
+import { Earthstar, Select } from "../deps.ts";
+
+const settings = new Earthstar.SharedSettings();
+
+if (settings.shares.length === 0) {
+  console.log("There are no known shares to remove!");
+  Deno.exit(0);
+}
+
+const choice = await Select.prompt({
+  message: "Which server would you like to be forgotten?",
+  options: settings.shares,
+});
+
+const isSure = confirm(
+  `Are you sure you want to forget ${choice} and all its data?`,
+);
+
+if (!isSure) {
+  Deno.exit(0);
+}
+
+settings.removeShare(choice);
+
+const replica = new Earthstar.Replica({
+  driver: new Earthstar.ReplicaDriverFs(
+    choice,
+    `./share_data/${choice}/`,
+  ),
+});
+
+// Delete all the data.
+await replica.close(true);
+
+console.log("✅ Removed");
+
+Deno.exit(0);

--- a/scripts/sync_all.ts
+++ b/scripts/sync_all.ts
@@ -1,0 +1,36 @@
+// Sync all known shares with all known servers.
+
+import { Earthstar } from "../deps.ts";
+
+const settings = new Earthstar.SharedSettings();
+
+const peer = new Earthstar.Peer();
+
+for (const share of settings.shares) {
+  const replica = new Earthstar.Replica({
+    driver: new Earthstar.ReplicaDriverFs(
+      share,
+      `./share_data/${share}/`,
+    ),
+  });
+
+  peer.addReplica(replica);
+}
+
+const syncOps = settings.servers.map((serverUrl) => {
+  const syncer = peer.sync(serverUrl);
+
+  syncer.isDone().then(() => {
+    console.log(`✅ Synced with ${serverUrl}`);
+  }).catch((err: Earthstar.EarthstarError) => {
+    console.group(`❌ Sync with ${serverUrl} failed`);
+    console.log(err);
+    console.groupEnd();
+  });
+
+  return syncer.isDone();
+});
+
+await Promise.allSettled(syncOps);
+
+Deno.exit(0);


### PR DESCRIPTION
Some new scripts:

- `current_author` displays the current author in shared settings
- `forget_author` removes the keypair stored in shared settings
- `list_servers` lists all servers in shared settings
- `list_shares` lists all shares in shared settings
- `remove_share` removes one share from shared settings
- `sync_all` syncs all known shares with all known servers